### PR TITLE
PacketType and SensorChannel enums. Update to 1.3.0. Fixed tests.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sifi-bridge-py"
-version = "1.2.3"
+version = "1.3.0"
 description = "Python bindings over the SiFi Bridge tool."
 authors = [{ name = "SiFi Labs", email = "gabrielg@sifilabs.com" }]
 dependencies = ["numpy", "requests>=2.32.3", "semantic-version>=2.10.0"]

--- a/tests/test.py
+++ b/tests/test.py
@@ -7,65 +7,67 @@ from sifi_bridge_py.sifi_bridge import (
     PpgSensitivity,
 )
 
+
 class TestSifiBridge(unittest.TestCase):
     sb = sbp.SifiBridge()
-       
+
     def test_show(self):
         assert "connected" in self.sb.show().keys()
-        
+
     def test_configure_ecg(self):
         self.sb.configure_ecg((1, 35))
-        
+
     def test_configure_emg(self):
         self.sb.configure_emg((1, 35), None)
         self.sb.configure_emg((1, 35), 50)
         self.sb.configure_emg((1, 35), 60)
-    
+
     def test_configure_eda(self):
         self.sb.configure_eda((1, 6), 0)
         self.sb.configure_eda((1, 6), 15)
         self.sb.configure_eda((1, 6), 50000)
-    
+
     def test_configure_ppg(self):
         self.sb.configure_ppg(8, 8, 8, 8, PpgSensitivity.LOW)
         self.sb.configure_ppg(8, 8, 8, 8, PpgSensitivity.MEDIUM)
         self.sb.configure_ppg(8, 8, 8, 8, PpgSensitivity.HIGH)
         self.sb.configure_ppg(8, 8, 8, 8, PpgSensitivity.MAX)
-    
+
     def test_configure_sampling_frequencies(self):
         self.sb.configure_sampling_freqs(500, 2000, 100, 100, 100)
-    
+
     def test_set_ble_power(self):
         self.sb.set_ble_power(BleTxPower.LOW)
         self.sb.set_ble_power(BleTxPower.MEDIUM)
         self.sb.set_ble_power(BleTxPower.HIGH)
-        
+
     def test_set_memory_mode(self):
         self.sb.set_memory_mode(MemoryMode.DEVICE)
         self.sb.set_memory_mode(MemoryMode.STREAMING)
         self.sb.set_memory_mode(MemoryMode.BOTH)
-        
+
     def test_set_channels(self):
         self.sb.set_channels(False, False, False, False, False)
         self.sb.set_channels(True, True, True, True, True)
-        
+
     def test_set_filters(self):
         self.sb.set_filters(True)
         self.sb.set_filters(False)
-        
+
     def test_set_low_latency_mode(self):
         self.sb.set_low_latency_mode(True)
         self.sb.set_low_latency_mode(False)
-    
+
     def test_list_devices(self):
         # self.sb.list_devices(sbp.ListSources.BLE) # could fail in runner?
         self.sb.list_devices(sbp.ListSources.DEVICES)
         self.sb.list_devices(sbp.ListSources.SERIAL)
 
     def test_select_device(self):
-        self.sb.select_device("device-1")
-        assert self.sb.active_device == "device-1"
-        
+        devs = self.sb.list_devices(sbp.ListSources.DEVICES)
+        self.sb.select_device(devs[0])
+        assert self.sb.active_device == devs[0]
+
     def test_create_device_no_select(self):
         test_device_name = "create_device_no_select"
         self.sb.select_device("device-1")
@@ -85,9 +87,11 @@ class TestSifiBridge(unittest.TestCase):
         assert test_device_name in self.sb.list_devices(sbp.ListSources.DEVICES)
         self.sb.delete_device(test_device_name)
         assert test_device_name not in self.sb.list_devices(sbp.ListSources.DEVICES)
-        
+
+
 if __name__ == "__main__":
-    # import logging
-    # logging.basicConfig(level=logging.DEBUG)
-    
+    import logging
+
+    logging.basicConfig(level=logging.DEBUG)
+
     unittest.main()


### PR DESCRIPTION
- Update for sifibridge 1.3.0
- `init` changed `data_output`  to `publishers`, allowing to configure none/one/multiple publishers alongside `stdout`
- Added PacketType enum with inline example
- Added SensorChannel enum with inline example